### PR TITLE
Remove datetime.now() from random.seed call

### DIFF
--- a/ColdToWarmPalette/ColdToWarmPalette.py
+++ b/ColdToWarmPalette/ColdToWarmPalette.py
@@ -448,7 +448,7 @@ class ColdToWarmPalette(DockWidget):
 
     def generateMixerColor(self): 
         cm = self.color_manager
-        random.seed(datetime.now())
+        random.seed()
 
         gap_limit = 30
         gap_interval = self.settings["mix_interval"]

--- a/ColdToWarmPalette/ColdToWarmPalette.py
+++ b/ColdToWarmPalette/ColdToWarmPalette.py
@@ -24,7 +24,6 @@
  
 from krita import *
 import  math, os, random, json
-from datetime import datetime
 from functools import partial
 
  
@@ -386,7 +385,7 @@ class ColdToWarmPalette(DockWidget):
     def generateSatStrip(self):
         cm = self.color_manager
 
-        random.seed(datetime.now())
+        random.seed()
         col =  self.gen_color[2][2].toHSV()
         self.sat_color[2].setColorHSV( col["H"], col["S"], col["V"]) 
 
@@ -410,7 +409,7 @@ class ColdToWarmPalette(DockWidget):
     def generateHueStrip(self):
         cm = self.color_manager
 
-        random.seed(datetime.now())
+        random.seed()
         col =  self.gen_color[2][2].toHSV()
         self.hue_color[2].setColorHSV( col["H"], col["S"], col["V"]) 
 
@@ -448,7 +447,7 @@ class ColdToWarmPalette(DockWidget):
 
     def generateMixerColor(self): 
         cm = self.color_manager
-        random.seed(datetime.now())
+        random.seed()
 
         gap_limit = 30
         gap_interval = self.settings["mix_interval"]


### PR DESCRIPTION
random.seed() doesn't support datetime, and the default seed is the current systemtime anyway

https://docs.python.org/3/library/random.html?highlight=random#random.seed

> Changed in version 3.11: The seed must be one of the following types: NoneType, [int](https://docs.python.org/3/library/functions.html#int), [float](https://docs.python.org/3/library/functions.html#float), [str](https://docs.python.org/3/library/stdtypes.html#str), [bytes](https://docs.python.org/3/library/stdtypes.html#bytes), or [bytearray](https://docs.python.org/3/library/stdtypes.html#bytearray).